### PR TITLE
Use single-sheet Excel filename

### DIFF
--- a/FastExcel/Worksheet.cs
+++ b/FastExcel/Worksheet.cs
@@ -39,7 +39,7 @@ namespace FastExcel
         /// </summary>
         public int ExistingHeadingRows { get; set; }
         private int? InsertAfterIndex { get; set; }
-        
+
         /// <summary>
         /// Template
         /// </summary>
@@ -71,6 +71,7 @@ namespace FastExcel
 
         private const string DEFAULT_HEADERS = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><sheetData>";
         private const string DEFAULT_FOOTERS = "</sheetData></worksheet>";
+        private const string SINGLE_SHEET = "worksheets/sheet.xml";
 
         /// <summary>
         /// Constructor
@@ -355,7 +356,8 @@ namespace FastExcel
             IEnumerable<Row> rows = null;
 
             var headings = new List<string>();
-            using (Stream stream = FastExcel.Archive.GetEntry(FileName).Open())
+            string filename = DecideFilename();
+            using (Stream stream = FastExcel.Archive.GetEntry(filename).Open())
             {
                 var document = XDocument.Load(stream);
                 int skipRows = 0;
@@ -377,6 +379,18 @@ namespace FastExcel
 
             Headings = headings;
             Rows = rows;
+        }
+
+        /// <summary>
+        /// Check if single sheet exists, and use that name accordingly.
+        /// </summary>
+        /// <returns>Filename</returns>
+        private string DecideFilename()
+        {
+            var filename = FastExcel.Archive.Entries.FirstOrDefault(x => x.FullName.Contains(SINGLE_SHEET))?.FullName;
+            if (filename == null)
+                filename = FileName;
+            return filename;
         }
 
         /// <summary>


### PR DESCRIPTION
If exists in zip, then use constant for filename, don't postfix filename with sheet number in this case.

I encountered this problem in some recent Excel .xlsx files, and fixed it in my clone.
This is probably a naive implementation, and I suspect this problem has something to do with the "standalone" xml attribute.