### PR TITLE
Update to .NET Standard 2.1 and Other Changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.4.0
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v1.9.0
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 6.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ jobs:
     name: build, pack & publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v1.9.0
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 6.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build
@@ -23,7 +23,7 @@ jobs:
       # Publish
       - name: publish on version change
         id: publish_nuget
-        uses: rohith/publish-nuget@v2
+        uses: brandedoutcast/publish-nuget@v2.5.5
         with:          
           PROJECT_FILE_PATH: FastExcel/FastExcel.csproj  
           NUGET_KEY: ${{secrets.NUGET_KEY}}

--- a/FastExcel.Tests/FastExcel.Tests.csproj
+++ b/FastExcel.Tests/FastExcel.Tests.csproj
@@ -1,11 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211130-02" />
     <PackageReference Include="xunit" Version="2.4.2-pre.12" />
@@ -14,11 +11,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\FastExcel\FastExcel.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="ResourcesTests\OneRowFile.xlsx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -36,5 +31,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/FastExcel.Tests/FastExcel.Tests.csproj
+++ b/FastExcel.Tests/FastExcel.Tests.csproj
@@ -1,15 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211130-02" />
+    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/FastExcel.Tests/FastExcelTests.cs
+++ b/FastExcel.Tests/FastExcelTests.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,7 +13,7 @@ namespace FastExcel.Tests
         private static readonly string ResourcesPath = Path.Combine(Environment.CurrentDirectory, "ResourcesTests");
         private static readonly string TemplateFilePath = Path.Combine(ResourcesPath, "template.xlsx");
 
-        private static readonly CellRow TestCellRow = new CellRow()
+        private static readonly CellRow TestCellRow = new()
         {
             StringColumn1 = "&",
             IntegerColumn2 = 45678854,
@@ -37,7 +36,7 @@ namespace FastExcel.Tests
 
             var action = new Action(() =>
             {
-                using (var fastExcel = new FastExcel(inputFile)) ;
+                using FastExcel fastExcel = new(inputFile);
             });
 
             var exception = Assert.Throws<FileNotFoundException>(action);
@@ -55,7 +54,7 @@ namespace FastExcel.Tests
 
             var action = new Action(() =>
             {
-                using (var fastExcel = new FastExcel(templateFile, outputFile)) ;
+                using FastExcel fastExcel = new(templateFile, outputFile);
             });
 
             var exception = Assert.Throws<FileNotFoundException>(action);
@@ -73,7 +72,7 @@ namespace FastExcel.Tests
 
             var action = new Action(() =>
             {
-                using (var fastExcel = new FastExcel(templateFile, outputFile)) ;
+                using FastExcel fastExcel = new(templateFile, outputFile);
             });
 
             var exception = Assert.Throws<Exception>(action);
@@ -88,10 +87,8 @@ namespace FastExcel.Tests
 
             var action = new Action(() =>
             {
-                using (var fastExcel = new FastExcel(inputFile, true))
-                {
-                    var worksheet = fastExcel.Read(1, 1);
-                }
+                using FastExcel fastExcel = new(inputFile, true);
+                var worksheet = fastExcel.Read(1, 1);
             });
 
             var exception = Record.Exception(action);
@@ -101,19 +98,23 @@ namespace FastExcel.Tests
         [Fact]
         public void ThrowsErrorIfInitializedWithStreamAndFileInfoIsAccessed()
         {
-            using var inputMemorystream = new MemoryStream(new byte[] {0x1});
+            using var inputMemorystream = new MemoryStream(new byte[] { 0x1 });
             using var outputMemorystream = new MemoryStream();
+
             var fastExcel = new FastExcel(inputMemorystream, outputMemorystream);
             var exception = Assert.Throws<ApplicationException>(() => fastExcel.ExcelFile);
-            Assert.Equal($"ExcelFile was not provided", exception.Message);
+
+            Assert.Equal("ExcelFile was not provided", exception.Message);
             exception = Assert.Throws<ApplicationException>(() => fastExcel.TemplateFile);
-            Assert.Equal($"TemplateFile was not provided", exception.Message);
+
+            Assert.Equal("TemplateFile was not provided", exception.Message);
         }
 
         private string FileRead_ReadingSpecialCharactersCore_Read(FileInfo inputFile)
         {
             inputFile.Refresh();
             using var fastExcel = new FastExcel(inputFile);
+
             var worksheet = fastExcel.Read("sheet1");
             var rows = worksheet.Rows;
 
@@ -132,14 +133,12 @@ namespace FastExcel.Tests
             return "Passed";
         }
 
-
         [Fact]
         public string FileRead_ReadingSpecialCharacters_Read()
         {
             var inputFilePath = new FileInfo(Path.Combine(ResourcesPath, "special-char.xlsx"));
             return FileRead_ReadingSpecialCharactersCore_Read(inputFilePath);
         }
-
 
         [Fact]
         public string FileWrite_WritingOneRow_Wrote()
@@ -151,12 +150,11 @@ namespace FastExcel.Tests
             var templateFilePath = new FileInfo(TemplateFilePath);
             using (var fastExcel = new FastExcel(templateFilePath, inputFilePath))
             {
-                List<CellRow> objectList = new List<CellRow>();
+                List<CellRow> objectList = new();
 
                 objectList.Add(TestCellRow);
                 fastExcel.Write(objectList, "sheet1", true);
             }
-
 
             return FileRead_ReadingSpecialCharactersCore_Read(inputFilePath);
         }
@@ -165,8 +163,10 @@ namespace FastExcel.Tests
         public string FileUpdate_UpdatingEmptyFile_Updated()
         {
             var worksheet = new Worksheet();
-            var cells = new List<CellRow>();
-            cells.Add(TestCellRow);
+            var cells = new List<CellRow>
+            {
+                TestCellRow
+            };
 
             worksheet.PopulateRows(cells, usePropertiesAsHeadings: true);
             var templateFile = new FileInfo(TemplateFilePath);
@@ -178,7 +178,6 @@ namespace FastExcel.Tests
                 fastExcel.Update(worksheet, "Sheet1");
             }
 
-
             return FileRead_ReadingSpecialCharactersCore_Read(inputFile);
         }
 
@@ -186,7 +185,7 @@ namespace FastExcel.Tests
         public string FileUpdate_UpdatingWithOneRow_Updated()
         {
             var worksheet = new Worksheet();
-            var cells = new List<CellRow> {TestCellRow};
+            var cells = new List<CellRow> { TestCellRow };
 
             worksheet.PopulateRows(cells, usePropertiesAsHeadings: true);
 
@@ -204,8 +203,10 @@ namespace FastExcel.Tests
         public string FileUpdate_WriteAndUpdatingWithOneRow_Updated()
         {
             var worksheet = new Worksheet();
-            var cells = new List<CellRow>();
-            cells.Add(TestCellRow);
+            var cells = new List<CellRow>
+            {
+                TestCellRow
+            };
 
             worksheet.PopulateRows(cells, usePropertiesAsHeadings: true);
 
@@ -216,7 +217,6 @@ namespace FastExcel.Tests
                 inputFile.Delete();
                 inputFile.Refresh();
             }
-
 
             //Writing Data One Row
             using (var fastExcel = new FastExcel(templateFile, inputFile))

--- a/FastExcel/Cell.cs
+++ b/FastExcel/Cell.cs
@@ -13,7 +13,7 @@ namespace FastExcel
     public class Cell
     {
         /// <summary>
-        /// Column Numnber (Starts at 1)
+        /// Column Number (Starts at 1)
         /// </summary>
         public int ColumnNumber { get; set; }
 
@@ -26,12 +26,12 @@ namespace FastExcel
         /// Defined name or the column letter(s) for column this cell is in
         /// </summary>
         public string ColumnName { get; }
-        
+
         /// <summary>
         /// Raw underlying XElement of cell
         /// </summary>
         public XElement XElement { get; }
-        
+
         /// <summary>
         /// List of defined names assigned to this cell
         /// *Does not include names of ranges this cell is within*
@@ -45,8 +45,11 @@ namespace FastExcel
         {
             get
             {
-                if (CellNames.Any())
-                    return CellNames.FirstOrDefault();
+                if (CellNames.Count > 0)
+                {
+                    return CellNames[0];
+                }
+
                 return ColumnName + RowNumber;
             }
         }
@@ -106,7 +109,7 @@ namespace FastExcel
             {
                 // cellElement.Value will give a concatenated Value + reference/calculation
 
-                var node = cellElement.Elements().Where(x => x.Name.LocalName == "v").SingleOrDefault();
+                var node = cellElement.Elements().SingleOrDefault(x => x.Name.LocalName == "v");
 
                 if (node != null)
                 {
@@ -116,7 +119,6 @@ namespace FastExcel
                 {
                     Value = cellElement.Value;
                 }
-                
             }
         }
 
@@ -147,7 +149,7 @@ namespace FastExcel
                     value = sharedStrings.AddString(value.ToString());
                 }
 
-                cell.AppendFormat("<c r=\"{0}{1}\"{2}>", GetExcelColumnName(ColumnNumber), rowNumber, (isString ? " t=\"s\"" : string.Empty));
+                cell.AppendFormat("<c r=\"{0}{1}\"{2}>", GetExcelColumnName(ColumnNumber), rowNumber, isString ? " t=\"s\"" : string.Empty);
                 cell.AppendFormat("<v>{0}</v>", value);
                 cell.Append("</c>");
             }
@@ -215,7 +217,7 @@ namespace FastExcel
         }
 
         /// <summary>
-        /// 
+        /// Returns a cell's Value as a String
         /// </summary>
         /// <returns>Cell's Value</returns>
         public override string ToString()

--- a/FastExcel/CellRange.cs
+++ b/FastExcel/CellRange.cs
@@ -47,7 +47,7 @@ namespace FastExcel
             // Default value
             RowStart = 1;
 
-            if (range.Contains(":"))
+            if (range.Contains(':'))
             {
                 string[] splitRange = range.Split(':');
                 ColumnStart = splitRange[0].Split('$')[1];

--- a/FastExcel/DefinedName.cs
+++ b/FastExcel/DefinedName.cs
@@ -3,7 +3,6 @@ using System.Xml.Linq;
 
 namespace FastExcel
 {
-
     /// <summary>
     /// Reads/hold information from XElement representing a stored DefinedName
     /// A defined name is an alias for a cell, multiple cells, a range of cells or multiple ranges of cells
@@ -23,7 +22,7 @@ namespace FastExcel
             {
                 try
                 {
-                    WorksheetIndex = Convert.ToInt32(e.Attribute("localSheetId").Value)+1;
+                    WorksheetIndex = Convert.ToInt32(e.Attribute("localSheetId").Value) + 1;
                 }
                 catch (Exception exception)
                 {

--- a/FastExcel/DefinedNameLoadException.cs
+++ b/FastExcel/DefinedNameLoadException.cs
@@ -2,7 +2,6 @@
 
 namespace FastExcel
 {
-
     /// <summary>
     /// Exception used during loading process of defined names
     /// </summary>
@@ -14,7 +13,21 @@ namespace FastExcel
         public DefinedNameLoadException(string message, Exception innerException = null)
             : base(message, innerException)
         {
+        }
 
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public DefinedNameLoadException() : base()
+        {
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="message">message</param>
+        public DefinedNameLoadException(string message) : base(message)
+        {
         }
     }
 }

--- a/FastExcel/DefinedNamesExtensions.cs
+++ b/FastExcel/DefinedNamesExtensions.cs
@@ -8,7 +8,6 @@ namespace FastExcel
     /// </summary>
     internal static class DefinedNamesExtensions
     {
-
         /// <summary>
         /// Finds all the cell names for a given cell
         /// </summary>

--- a/FastExcel/FastExcel.DefinedName.cs
+++ b/FastExcel/FastExcel.DefinedName.cs
@@ -5,7 +5,7 @@ using System.Xml.Linq;
 
 namespace FastExcel
 {
-    partial class FastExcel
+    public partial class FastExcel
     {
         /// <summary>
         /// Dictionary of defined names
@@ -48,7 +48,6 @@ namespace FastExcel
                 var currentDefinedName = new DefinedName(e);
                 _definedNames.Add(currentDefinedName.Key, currentDefinedName);
             }
-
         }
 
         /// <summary>
@@ -93,12 +92,14 @@ namespace FastExcel
 
         /// <summary>
         /// Gets all cells by defined name
-        /// Like GetCellRangesByCellName, but just retreives all cells in a single list
+        /// Like GetCellRangesByCellName, but just retrieves all cells in a single list
         /// </summary>
         /// <param name="definedName"></param>
         /// <param name="worksheetIndex"></param>
         /// <returns></returns>
+#pragma warning disable RCS1163 // Unused parameter.
         public IEnumerable<Cell> GetCellsByDefinedName(string definedName, int? worksheetIndex = null)
+#pragma warning restore RCS1163 // Unused parameter.
         {
             var cells = new List<Cell>();
             var cellRanges = GetCellRangesByDefinedName(definedName) as List<List<Cell>>;
@@ -119,7 +120,7 @@ namespace FastExcel
         {
             return GetCellsByDefinedName(definedName, worksheetIndex).FirstOrDefault();
         }
-        
+
         /// <summary>
         /// Returns all cells in a column by name, within optional row range
         /// </summary>

--- a/FastExcel/FastExcel.Read.cs
+++ b/FastExcel/FastExcel.Read.cs
@@ -37,7 +37,7 @@ namespace FastExcel
             else
             {
                 worksheet = (from w in Worksheets
-                             where (sheetNumber.HasValue && sheetNumber.Value == w.Index) ||
+                             where (sheetNumber == w.Index) ||
                                     (sheetName == w.Name)
                              select w).SingleOrDefault();
                 worksheet.Read(existingHeadingRows);

--- a/FastExcel/FastExcel.Update.cs
+++ b/FastExcel/FastExcel.Update.cs
@@ -29,9 +29,9 @@
 
             Worksheet currentData = Read(sheetNumber, sheetName);
             currentData.Merge(data);
-            if(sheetName!=null)
+            if (sheetName != null)
                 Write(currentData, sheetName);
-            else if(sheetNumber!=null)
+            else if (sheetNumber != null)
                 Write(currentData, sheetNumber);
             else
                 Write(currentData);

--- a/FastExcel/FastExcel.cs
+++ b/FastExcel/FastExcel.cs
@@ -6,18 +6,20 @@ using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 
-namespace FastExcel {
+namespace FastExcel
+{
     /// <summary>
     /// Fast Excel
     /// </summary>
-    public partial class FastExcel : IDisposable {
-
+    public partial class FastExcel : IDisposable
+    {
         /// <summary>
         ///  Output excel file
         /// </summary>
         public FileInfo ExcelFile
         {
-            get {
+            get
+            {
                 if (_excelFile == null)
                 {
                     throw new ApplicationException("ExcelFile was not provided");
@@ -28,7 +30,8 @@ namespace FastExcel {
         /// <summary>
         /// The template excel file
         /// </summary>
-        public FileInfo TemplateFile{
+        public FileInfo TemplateFile
+        {
             get
             {
                 if (_templateFile == null)
@@ -60,12 +63,12 @@ namespace FastExcel {
         internal int MaxSheetNumber { get; set; }
 
         /// <summary>
-        /// A list of worksheet indexs to delete
+        /// A list of worksheet indexes to delete
         /// </summary>
         private List<int> DeleteWorksheets { get; set; }
 
         /// <summary>
-        /// A list of worksheet indexs to insert
+        /// A list of worksheet indexes to insert
         /// </summary>
         private List<WorksheetAddSettings> AddWorksheets { get; set; }
 
@@ -74,7 +77,8 @@ namespace FastExcel {
         /// </summary>
         /// <param name="excelFile">location of an existing excel file</param>
         /// <param name="readOnly">is the file read only</param>
-        public FastExcel(FileInfo excelFile, bool readOnly = false) : this(null, excelFile, true, readOnly) {
+        public FastExcel(FileInfo excelFile, bool readOnly = false) : this(null, excelFile, true, readOnly)
+        {
         }
 
         /// <summary>
@@ -82,36 +86,43 @@ namespace FastExcel {
         /// </summary>
         /// <param name="templateFile">template location</param>
         /// <param name="excelFile">location of where a new excel file will be saved to</param>
-        public FastExcel(FileInfo templateFile, FileInfo excelFile) : this(templateFile, excelFile, false, false) {
+        public FastExcel(FileInfo templateFile, FileInfo excelFile) : this(templateFile, excelFile, false, false)
+        {
         }
 
         /// <summary>
-        /// 
+        /// Constructor
         /// </summary>
         /// <param name="templateFile"></param>
         /// <param name="excelFile"></param>
         /// <param name="updateExisting"></param>
         /// <param name="readOnly"></param>
-        private FastExcel(FileInfo templateFile, FileInfo excelFile, bool updateExisting, bool readOnly = false) {
-            if (updateExisting) {
-                if (!excelFile.Exists) {
+        private FastExcel(FileInfo templateFile, FileInfo excelFile, bool updateExisting, bool readOnly = false)
+        {
+            if (updateExisting)
+            {
+                if (!excelFile.Exists)
+                {
                     var exceptionMessage = $"Input file '{excelFile.FullName}' does not exist";
                     throw new FileNotFoundException(exceptionMessage);
                 }
             }
-            else {
-                if (excelFile.Exists) {
+            else
+            {
+                if (excelFile.Exists)
+                {
                     var exceptionMessage = $"Output file '{excelFile.FullName}' already exists";
                     throw new Exception(exceptionMessage);
                 }
-                if (!templateFile.Exists) {
+                if (!templateFile.Exists)
+                {
                     var exceptionMessage = $"Template file '{templateFile.FullName}' was not found";
                     throw new FileNotFoundException(exceptionMessage);
                 }
             }
             _templateFile = templateFile;
             _excelFile = excelFile;
-            TemplateFileStream = templateFile !=  null ? new FileStream(templateFile.FullName, FileMode.Open, FileAccess.Read) : null;
+            TemplateFileStream = templateFile != null ? new FileStream(templateFile.FullName, FileMode.Open, FileAccess.Read) : null;
             ExcelFileStream = updateExisting
                 ? new FileStream(excelFile.FullName, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite)
                 : new FileStream(excelFile.FullName, FileMode.OpenOrCreate, FileAccess.ReadWrite);
@@ -125,7 +136,8 @@ namespace FastExcel {
         /// Update an existing excel file stream
         /// </summary>
         /// <param name="excelStream"></param>
-        public FastExcel(Stream excelStream) : this(null, excelStream, true) {
+        public FastExcel(Stream excelStream) : this(null, excelStream, true)
+        {
         }
 
         /// <summary>
@@ -135,7 +147,8 @@ namespace FastExcel {
         /// <param name="excelStream">Output Excel Stream</param>
         /// <param name="updateExisting"></param>
         /// <param name="readOnly"></param>
-        public FastExcel(Stream templateStream, Stream excelStream, bool updateExisting = false, bool readOnly = false) {
+        public FastExcel(Stream templateStream, Stream excelStream, bool updateExisting = false, bool readOnly = false)
+        {
             if (templateStream is FileStream templatefileStream)
             {
                 _templateFile = new FileInfo(templatefileStream.Name);
@@ -151,18 +164,23 @@ namespace FastExcel {
             CheckFiles();
         }
 
-        internal void PrepareArchive(bool openSharedStrings = true) {
-            if (Archive == null) {
-                if (ReadOnly) {
+        internal void PrepareArchive(bool openSharedStrings = true)
+        {
+            if (Archive == null)
+            {
+                if (ReadOnly)
+                {
                     Archive = new ZipArchive(ExcelFileStream, ZipArchiveMode.Read);
                 }
-                else {
+                else
+                {
                     Archive = new ZipArchive(ExcelFileStream, ZipArchiveMode.Update);
                 }
             }
 
             // Get Strings file
-            if (SharedStrings == null && openSharedStrings) {
+            if (SharedStrings == null && openSharedStrings)
+            {
                 SharedStrings = new SharedStrings(Archive);
             }
         }
@@ -170,27 +188,34 @@ namespace FastExcel {
         /// <summary>
         /// Ensure files are ready for use
         /// </summary>
-        internal void CheckFiles() {
-            if (_filesChecked) {
+        internal void CheckFiles()
+        {
+            if (_filesChecked)
+            {
                 return;
             }
 
-            if (UpdateExisting) {
-                if (ExcelFileStream?.Length == 0) {
+            if (UpdateExisting)
+            {
+                if (ExcelFileStream?.Length == 0)
+                {
                     throw new Exception("No input file name was supplied");
                 }
             }
-            else {
-                if (TemplateFileStream == null) {
+            else
+            {
+                if (TemplateFileStream == null)
+                {
                     throw new Exception("No Template file was supplied");
                 }
 
-                if (ExcelFileStream == null) {
-                    throw new Exception("No Ouput file name was supplied");
+                if (ExcelFileStream == null)
+                {
+                    throw new Exception("No Output file name was supplied");
                 }
-                else if (ExcelFileStream.Length > 0) {
-                    var exceptionMessage = $"Output file  already exists";
-                    throw new Exception(exceptionMessage);
+                else if (ExcelFileStream.Length > 0)
+                {
+                    throw new Exception("Output file  already exists");
                 }
             }
 
@@ -200,101 +225,115 @@ namespace FastExcel {
         /// <summary>
         /// Update xl/_rels/workbook.xml.rels file
         /// </summary>
-        private void UpdateRelations(bool ensureStrings) {
+        private void UpdateRelations(bool ensureStrings)
+        {
             if (!(ensureStrings ||
-                  (DeleteWorksheets != null && DeleteWorksheets.Any()) ||
-                  (AddWorksheets != null && AddWorksheets.Any()))) {
+                  (DeleteWorksheets?.Any() == true) ||
+                  (AddWorksheets?.Any() == true)))
+            {
                 // Nothing to update
                 return;
             }
 
-            using (Stream stream = Archive.GetEntry("xl/_rels/workbook.xml.rels").Open()) {
-                XDocument document = XDocument.Load(stream);
+            using Stream stream = Archive.GetEntry("xl/_rels/workbook.xml.rels").Open();
+            XDocument document = XDocument.Load(stream);
 
-                if (document == null) {
-                    //TODO error
+            if (document == null)
+            {
+                throw new FileLoadException("Excel Document Loaded Was Invalid");
+            }
+
+            bool update = false;
+
+            List<XElement> relationshipElements = document.Descendants().Where(d => d.Name.LocalName == "Relationship").ToList();
+            int id = relationshipElements.Count;
+            if (ensureStrings)
+            {
+                //Ensure SharedStrings
+                XElement relationshipElement = (from element in relationshipElements
+                                                from attribute in element.Attributes()
+                                                where attribute.Name == "Target" && attribute.Value.Equals("sharedStrings.xml", StringComparison.OrdinalIgnoreCase)
+                                                select element).FirstOrDefault();
+
+                if (relationshipElement == null)
+                {
+                    relationshipElement = new XElement(document.Root.GetDefaultNamespace() + "Relationship");
+                    relationshipElement.Add(new XAttribute("Target", "sharedStrings.xml"));
+                    relationshipElement.Add(new XAttribute("Type", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"));
+                    relationshipElement.Add(new XAttribute("Id", string.Format("rId{0}", ++id)));
+
+                    document.Root.Add(relationshipElement);
+                    update = true;
                 }
+            }
 
-                bool update = false;
-
-                List<XElement> relationshipElements = document.Descendants().Where(d => d.Name.LocalName == "Relationship").ToList();
-                int id = relationshipElements.Count;
-                if (ensureStrings) {
-                    //Ensure SharedStrings
-                    XElement relationshipElement = (from element in relationshipElements
-                        from attribute in element.Attributes()
-                        where attribute.Name == "Target" && attribute.Value.Equals("sharedStrings.xml", StringComparison.OrdinalIgnoreCase)
-                        select element).FirstOrDefault();
-
-                    if (relationshipElement == null) {
-                        relationshipElement = new XElement(document.Root.GetDefaultNamespace() + "Relationship");
-                        relationshipElement.Add(new XAttribute("Target", "sharedStrings.xml"));
-                        relationshipElement.Add(new XAttribute("Type", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"));
-                        relationshipElement.Add(new XAttribute("Id", string.Format("rId{0}", ++id)));
-
-                        document.Root.Add(relationshipElement);
-                        update = true;
-                    }
+            // Remove all references to sheets from this file as they are not required
+            if ((DeleteWorksheets?.Any() == true) ||
+                (AddWorksheets?.Any() == true))
+            {
+                XElement[] worksheetElements = (from element in relationshipElements
+                                                from attribute in element.Attributes()
+                                                where attribute.Name == "Type" && attribute.Value == "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"
+                                                select element).ToArray();
+                for (int i = worksheetElements.Length - 1; i > 0; i--)
+                {
+                    worksheetElements[i].Remove();
+                    update = true;
                 }
+            }
 
-                // Remove all references to sheets from this file as they are not requried
-                if ((DeleteWorksheets != null && DeleteWorksheets.Any()) ||
-                    (AddWorksheets != null && AddWorksheets.Any())) {
-                    XElement[] worksheetElements = (from element in relationshipElements
-                        from attribute in element.Attributes()
-                        where attribute.Name == "Type" && attribute.Value == "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"
-                        select element).ToArray();
-                    for (int i = worksheetElements.Length - 1; i > 0; i--) {
-                        worksheetElements[i].Remove();
-                        update = true;
-                    }
-                }
+            if (update)
+            {
+                // Set the stream to the start
+                stream.Position = 0;
+                // Clear the stream
+                stream.SetLength(0);
 
-                if (update) {
-                    // Set the stream to the start
-                    stream.Position = 0;
-                    // Clear the stream
-                    stream.SetLength(0);
-
-                    // Open the stream so we can override all content of the sheet
-                    StreamWriter streamWriter = new StreamWriter(stream, Encoding.UTF8);
-                    document.Save(streamWriter);
-                    streamWriter.Flush();
-                }
+                // Open the stream so we can override all content of the sheet
+                StreamWriter streamWriter = new StreamWriter(stream, Encoding.UTF8);
+                document.Save(streamWriter);
+                streamWriter.Flush();
             }
         }
 
         /// <summary>
         /// Update xl/workbook.xml file
         /// </summary>
-        private string[] UpdateWorkbook() {
-            if (!(DeleteWorksheets != null && DeleteWorksheets.Any() ||
-                  (AddWorksheets != null && AddWorksheets.Any()))) {
+        /// <param name="update">[Optional(default false)]force a re-write of all sheets</param>
+        private string[] UpdateWorkbook(bool update = false)
+        {
+            if (!((DeleteWorksheets?.Any() == true) ||
+                  (AddWorksheets?.Any() == true)))
+            {
                 // Nothing to update
                 return null;
             }
 
-            List<string> sheetNames = new List<string>();
-            using (Stream stream = Archive.GetEntry("xl/workbook.xml").Open()) {
+            List<string> sheetNames = new List<String>();
+            using (Stream stream = Archive.GetEntry("xl/workbook.xml").Open())
+            {
                 XDocument document = XDocument.Load(stream);
 
-                if (document == null) {
+                if (document == null)
+                {
                     throw new Exception("Unable to load workbook.xml");
                 }
 
-                bool update = false;
-
                 RenameAndRebildWorksheetProperties((from sheet in document.Descendants()
-                    where sheet.Name.LocalName == "sheet"
-                    select sheet).ToArray());
+                                                    where sheet.Name.LocalName == "sheet"
+                                                    select sheet).ToArray());
 
-                if (update) {
+                //bool update = false; //made this into an optional function parameter instead.
+
+                if (update)
+                {
                     // Re number sheet ids
                     XNamespace r = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
                     int id = 1;
                     foreach (XElement sheetElement in (from sheet in document.Descendants()
-                        where sheet.Name.LocalName == "sheet"
-                        select sheet)) {
+                                                       where sheet.Name.LocalName == "sheet"
+                                                       select sheet))
+                    {
                         sheetElement.SetAttributeValue(r + "id", string.Format("rId{0}", id++));
                         sheetNames.Add(sheetElement.Attribute("name").Value);
                     }
@@ -314,13 +353,14 @@ namespace FastExcel {
             return sheetNames.ToArray();
         }
 
-
         /// <summary>
         /// If sheets have been added or deleted, sheets need to be renamed
         /// </summary>
-        private void RenameAndRebildWorksheetProperties(XElement[] sheets) {
-            if (!((DeleteWorksheets != null && DeleteWorksheets.Any()) ||
-                  (AddWorksheets != null && AddWorksheets.Any()))) {
+        private void RenameAndRebildWorksheetProperties(XElement[] sheets)
+        {
+            if (!((DeleteWorksheets?.Any() == true) ||
+                  (AddWorksheets?.Any() == true)))
+            {
                 // Nothing to update
                 return;
             }
@@ -328,39 +368,47 @@ namespace FastExcel {
             XNamespace r = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 
             List<WorksheetProperties> sheetProperties = (from sheet in sheets
-                select new WorksheetProperties
-                    () {
-                        SheetId = int.Parse(sheet.Attribute("sheetId").Value),
-                        Name = sheet.Attribute("name").Value,
-                        CurrentIndex = int.Parse(sheet.Attribute(r + "id").Value)
-                    }).ToList();
+                                                         select new WorksheetProperties
+                                                             ()
+                                                         {
+                                                             SheetId = int.Parse(sheet.Attribute("sheetId").Value),
+                                                             Name = sheet.Attribute("name").Value,
+                                                             CurrentIndex = int.Parse(sheet.Attribute(r + "id").Value)
+                                                         }).ToList();
 
             // Remove deleted worksheets to sheetProperties
-            if (DeleteWorksheets != null && DeleteWorksheets.Any()) {
-                foreach (var item in DeleteWorksheets) {
+            if (DeleteWorksheets?.Any() == true)
+            {
+                foreach (var item in DeleteWorksheets)
+                {
                     WorksheetProperties sheetToDelete = (from sp in sheetProperties
-                        where sp.SheetId == item
-                        select sp).FirstOrDefault();
+                                                         where sp.SheetId == item
+                                                         select sp).FirstOrDefault();
 
-                    if (sheetToDelete != null) {
+                    if (sheetToDelete != null)
+                    {
                         sheetProperties.Remove(sheetToDelete);
                     }
                 }
             }
 
             // Add new worksheets to sheetProperties
-            if (AddWorksheets != null && AddWorksheets.Any()) {
+            if (AddWorksheets?.Any() == true)
+            {
                 // Add the sheets in reverse, this will add them correctly with less work
-                foreach (var item in AddWorksheets.Reverse<WorksheetAddSettings>()) {
+                foreach (var item in AddWorksheets.Reverse<WorksheetAddSettings>())
+                {
                     WorksheetProperties previousSheet = (from sp in sheetProperties
-                        where sp.SheetId == item.InsertAfterSheetId
-                        select sp).FirstOrDefault();
+                                                         where sp.SheetId == item.InsertAfterSheetId
+                                                         select sp).FirstOrDefault();
 
-                    if (previousSheet == null) {
+                    if (previousSheet == null)
+                    {
                         throw new Exception(string.Format("Sheet name {0} cannot be added because the insertAfterSheetNumber or insertAfterSheetName is now invalid", item.Name));
                     }
 
-                    WorksheetProperties newWorksheet = new WorksheetProperties() {
+                    WorksheetProperties newWorksheet = new WorksheetProperties()
+                    {
                         SheetId = item.SheetId,
                         Name = item.Name,
                         CurrentIndex = 0 // TODO Something??
@@ -370,10 +418,13 @@ namespace FastExcel {
             }
 
             int index = 1;
-            foreach (WorksheetProperties worksheet in sheetProperties) {
-                if (worksheet.CurrentIndex != index) {
+            foreach (WorksheetProperties worksheet in sheetProperties)
+            {
+                if (worksheet.CurrentIndex != index)
+                {
                     ZipArchiveEntry entry = Archive.GetEntry(Worksheet.GetFileName(worksheet.CurrentIndex));
-                    if (entry == null) {
+                    if (entry == null)
+                    {
                         // TODO better message
                         throw new Exception("Worksheets could not be rebuilt");
                     }
@@ -386,82 +437,96 @@ namespace FastExcel {
         /// <summary>
         /// Update [Content_Types].xml file
         /// </summary>
-        private void UpdateContentTypes(bool ensureStrings) {
+        /// <exception cref="ArgumentNullException"></exception>
+        private void UpdateContentTypes(bool ensureStrings)
+        {
             if (!(ensureStrings ||
-                  (DeleteWorksheets != null && DeleteWorksheets.Any()) ||
-                  (AddWorksheets != null && AddWorksheets.Any()))) {
+                  (DeleteWorksheets?.Count > 0) ||
+                  (AddWorksheets?.Any() == true)))
+            {
                 // Nothing to update
                 return;
             }
 
-            using (Stream stream = Archive.GetEntry("[Content_Types].xml").Open()) {
-                XDocument document = XDocument.Load(stream);
+            using Stream stream = Archive.GetEntry("[Content_Types].xml").Open();
+            XDocument document = XDocument.Load(stream);
 
-                if (document == null) {
-                    //TODO error
+            if (document == null)
+            {
+                throw new FileLoadException("Content Types Do Not Exist");
+            }
+
+            bool update = false;
+            List<XElement> overrideElements = document.Descendants().Where(d => d.Name.LocalName == "Override").ToList();
+
+            //Ensure SharedStrings
+            if (ensureStrings)
+            {
+                XElement overrideElement = (from element in overrideElements
+                                            from attribute in element.Attributes()
+                                            where attribute.Name == "PartName" && attribute.Value.Equals("/xl/sharedStrings.xml",
+                                            StringComparison.OrdinalIgnoreCase)
+                                            select element).FirstOrDefault();
+
+                if (overrideElement == null)
+                {
+                    overrideElement = new XElement(document.Root.GetDefaultNamespace() + "Override");
+                    overrideElement.Add(new XAttribute(
+                        "ContentType",
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"));
+                    overrideElement.Add(new XAttribute("PartName", "/xl/sharedStrings.xml"));
+
+                    document.Root.Add(overrideElement);
+                    update = true;
                 }
+            }
 
-                bool update = false;
-                List<XElement> overrideElements = document.Descendants().Where(d => d.Name.LocalName == "Override").ToList();
+            if (DeleteWorksheets?.Any() == true)
+            {
+                foreach (var item in DeleteWorksheets)
+                {
+                    // the file name is different for each XML file
+                    string fileName = string.Format("/xl/worksheets/sheet{0}.xml", item);
 
-                //Ensure SharedStrings
-                if (ensureStrings) {
                     XElement overrideElement = (from element in overrideElements
-                        from attribute in element.Attributes()
-                        where attribute.Name == "PartName" && attribute.Value.Equals("/xl/sharedStrings.xml", StringComparison.OrdinalIgnoreCase)
-                        select element).FirstOrDefault();
-
-                    if (overrideElement == null) {
-                        overrideElement = new XElement(document.Root.GetDefaultNamespace() + "Override");
-                        overrideElement.Add(new XAttribute("ContentType", "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"));
-                        overrideElement.Add(new XAttribute("PartName", "/xl/sharedStrings.xml"));
-
-                        document.Root.Add(overrideElement);
+                                                from attribute in element.Attributes()
+                                                where attribute.Name == "PartName" && attribute.Value == fileName
+                                                select element).FirstOrDefault();
+                    if (overrideElement != null)
+                    {
+                        overrideElement.Remove();
                         update = true;
                     }
                 }
+            }
 
-                if (DeleteWorksheets != null && DeleteWorksheets.Any()) {
-                    foreach (var item in DeleteWorksheets) {
-                        // the file name is different for each xml file
-                        string fileName = string.Format("/xl/worksheets/sheet{0}.xml", item);
+            if (AddWorksheets?.Any() == true)
+            {
+                foreach (var item in AddWorksheets)
+                {
+                    // the file name is different for each XML file
+                    string fileName = string.Format("/xl/worksheets/sheet{0}.xml", item.SheetId);
 
-                        XElement overrideElement = (from element in overrideElements
-                            from attribute in element.Attributes()
-                            where attribute.Name == "PartName" && attribute.Value == fileName
-                            select element).FirstOrDefault();
-                        if (overrideElement != null) {
-                            overrideElement.Remove();
-                            update = true;
-                        }
-                    }
+                    XElement overrideElement = new XElement(document.Root.GetDefaultNamespace() + "Override");
+                    overrideElement.Add(new XAttribute("ContentType", "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"));
+                    overrideElement.Add(new XAttribute("PartName", fileName));
+
+                    document.Root.Add(overrideElement);
+                    update = true;
                 }
+            }
 
-                if (AddWorksheets != null && AddWorksheets.Any()) {
-                    foreach (var item in AddWorksheets) {
-                        // the file name is different for each xml file
-                        string fileName = string.Format("/xl/worksheets/sheet{0}.xml", item.SheetId);
+            if (update)
+            {
+                // Set the stream to the start
+                stream.Position = 0;
+                // Clear the stream
+                stream.SetLength(0);
 
-                        XElement overrideElement = new XElement(document.Root.GetDefaultNamespace() + "Override");
-                        overrideElement.Add(new XAttribute("ContentType", "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"));
-                        overrideElement.Add(new XAttribute("PartName", fileName));
-
-                        document.Root.Add(overrideElement);
-                        update = true;
-                    }
-                }
-
-                if (update) {
-                    // Set the stream to the start
-                    stream.Position = 0;
-                    // Clear the stream
-                    stream.SetLength(0);
-
-                    // Open the stream so we can override all content of the sheet
-                    StreamWriter streamWriter = new StreamWriter(stream, Encoding.UTF8);
-                    document.Save(streamWriter);
-                    streamWriter.Flush();
-                }
+                // Open the stream so we can override all content of the sheet
+                StreamWriter streamWriter = new StreamWriter(stream, Encoding.UTF8);
+                document.Save(streamWriter);
+                streamWriter.Flush();
             }
         }
 
@@ -470,14 +535,19 @@ namespace FastExcel {
         /// </summary>
         /// <param name="name"></param>
         /// <returns>1 based index of sheet or 0 if not found</returns>
-        public int GetWorksheetIndexFromName(string name) {
+        public int GetWorksheetIndexFromName(string name)
+        {
             return (from worksheet in Worksheets where worksheet.Name == name select worksheet.Index).FirstOrDefault();
         }
 
         /// <summary>
         /// Update docProps/app.xml file
         /// </summary>
-        private void UpdateDocPropsApp(string[] sheetNames) {
+        /// <param name="sheetNames"></param>
+#pragma warning disable RCS1163 // Unused parameter.
+        private static void UpdateDocPropsApp(string[] sheetNames)
+#pragma warning restore RCS1163 // Unused parameter.
+        {
             /* if (sheetNames == null || !sheetNames.Any())
              {
                  // Nothing to update
@@ -552,7 +622,8 @@ namespace FastExcel {
         /// <summary>
         /// Saves any pending changes to the Excel stream and adds/updates associated files if needed
         /// </summary>
-        public void Dispose() {
+        public void Dispose()
+        {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
@@ -560,16 +631,20 @@ namespace FastExcel {
         /// <summary>
         /// Main disposal function
         /// </summary>
-        protected virtual void Dispose(bool disposing) {
-            if (Archive == null) {
+        protected virtual void Dispose(bool disposing)
+        {
+            if (Archive == null)
+            {
                 return;
             }
 
-            if (Archive.Mode != ZipArchiveMode.Read) {
+            if (Archive.Mode != ZipArchiveMode.Read)
+            {
                 bool ensureSharedStrings = false;
 
                 // Update or create xl/sharedStrings.xml file
-                if (SharedStrings != null) {
+                if (SharedStrings != null)
+                {
                     ensureSharedStrings = SharedStrings.PendingChanges;
                     SharedStrings.Write();
                 }

--- a/FastExcel/FastExcel.csproj
+++ b/FastExcel/FastExcel.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>FastExcel</PackageId>
@@ -22,5 +21,4 @@
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\FastExcel.xml</DocumentationFile>
   </PropertyGroup>
-
 </Project>

--- a/FastExcel/FastExcel.csproj
+++ b/FastExcel/FastExcel.csproj
@@ -1,21 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>FastExcel</PackageId>
     <Authors>Jono Clarnette, Ahmed Massoud</Authors>
     <Description>A fast way to read and write to Excel *.xlsx files without using the Open XML library.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>Copyright 2016-2020 Jono Clarnette</Copyright>
     <PackageTags>fast excel xlsx read write</PackageTags>
-    <PackageLicenseUrl>https://github.com/ahmedwalid05/FastExcel/blob/master/LICENSE</PackageLicenseUrl>
+	<license>https://github.com/ahmedwalid05/FastExcel/blob/master/LICENSE</license>
+    <!--<PackageLicenseUrl>https://github.com/ahmedwalid05/FastExcel/blob/master/LICENSE</PackageLicenseUrl>-->
     <PackageProjectUrl>https://github.com/ahmedwalid05/FastExcel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ahmedwalid05/FastExcel</RepositoryUrl>
     <NeutralLanguage>en</NeutralLanguage>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
-    <Version>3.0.13</Version>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
+    <Version>3.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/FastExcel/Row.cs
+++ b/FastExcel/Row.cs
@@ -50,7 +50,7 @@ namespace FastExcel
             {
                 throw new Exception("Row Number not found", ex);
             }
-                        
+
             if (rowElement.HasElements)
             {
                 Cells = GetCells(rowElement, worksheet);
@@ -70,7 +70,7 @@ namespace FastExcel
         // <summary>
         // Get all cells in this row.
         // </summary>
-        private IEnumerable<Cell> GetCells(XElement rowElement, Worksheet worksheet)
+        private static IEnumerable<Cell> GetCells(XElement rowElement, Worksheet worksheet)
         {
             foreach (XElement cellElement in rowElement.Elements())
             {
@@ -85,7 +85,7 @@ namespace FastExcel
         {
             var row = new StringBuilder();
 
-            if (Cells != null && Cells.Any())
+            if (Cells?.Any() == true)
             {
                 row.AppendFormat("<row r=\"{0}\">", RowNumber);
                 try
@@ -129,8 +129,8 @@ namespace FastExcel
 
             // Sort
             Cells = (from c in outputList
-                          orderby c.ColumnNumber
-                          select c);
+                     orderby c.ColumnNumber
+                     select c);
         }
     }
 }

--- a/FastExcel/SharedStrings.cs
+++ b/FastExcel/SharedStrings.cs
@@ -13,11 +13,11 @@ namespace FastExcel
     public class SharedStrings
     {
         //A dictionary is a lot faster than a list
-        private Dictionary<string, int> StringDictionary { get; set; }
+        private Dictionary<string, int> StringDictionary { get; }
         private Dictionary<int, string> StringArray { get; set; }
 
-        private bool SharedStringsExists { get; set; }
-        private ZipArchive ZipArchive { get; set; }
+        private bool SharedStringsExists { get; }
+        private ZipArchive ZipArchive { get; }
 
         /// <summary>
         /// Is there any pending changes
@@ -35,43 +35,41 @@ namespace FastExcel
 
             SharedStringsExists = true;
 
-            if (!ZipArchive.Entries.Where(entry => entry.FullName == "xl/sharedStrings.xml").Any())
+            if (!ZipArchive.Entries.Any(entry => entry.FullName == "xl/sharedStrings.xml"))
             {
                 StringDictionary = new Dictionary<string, int>();
                 SharedStringsExists = false;
                 return;
             }
 
-            using (Stream stream = ZipArchive.GetEntry("xl/sharedStrings.xml").Open())
+            using Stream stream = ZipArchive.GetEntry("xl/sharedStrings.xml").Open();
+            if (stream == null)
             {
-                if (stream == null)
-                {
-                    StringDictionary = new Dictionary<string, int>();
-                    SharedStringsExists = false;
-                    return;
-                }
-
-                var document = XDocument.Load(stream);
-
-                if (document == null)
-                {
-                    StringDictionary = new Dictionary<string, int>();
-                    SharedStringsExists = false;
-                    return;
-                }
-
-                // int i = 0;
-                // StringDictionary = document.Descendants().Where(d => d.Name.LocalName == "t").Select(e => e.Value).Select(XmlConvert.DecodeName).to
-                //     .ToDictionary(k => k, v => i++);
-                int i = 0;
                 StringDictionary = new Dictionary<string, int>();
-                List<string> StringList = new List<string>();
-                StringList = document.Descendants().Where(d => d.Name.LocalName == "t").Select(e => XmlConvert.DecodeName(e.Value)).ToList();
-                foreach (string currentString in StringList)
-                {
-                    if (!StringDictionary.ContainsKey(currentString))
-                        StringDictionary.Add(currentString, i++);
-                }
+                SharedStringsExists = false;
+                return;
+            }
+
+            var document = XDocument.Load(stream);
+
+            if (document == null)
+            {
+                StringDictionary = new Dictionary<string, int>();
+                SharedStringsExists = false;
+                return;
+            }
+
+            // int i = 0;
+            // StringDictionary = document.Descendants().Where(d => d.Name.LocalName == "t").Select(e => e.Value).Select(XmlConvert.DecodeName).to
+            //     .ToDictionary(k => k, v => i++);
+            int i = 0;
+            StringDictionary = new Dictionary<string, int>();
+            List<string> StringList = new List<string>();
+            StringList = document.Descendants().Where(d => d.Name.LocalName == "t").Select(e => XmlConvert.DecodeName(e.Value)).ToList();
+            foreach (string currentString in StringList)
+            {
+                if (!StringDictionary.ContainsKey(currentString))
+                    StringDictionary.Add(currentString, i++);
             }
         }
 

--- a/FastExcel/Worksheet.cs
+++ b/FastExcel/Worksheet.cs
@@ -39,7 +39,7 @@ namespace FastExcel
         /// </summary>
         public int ExistingHeadingRows { get; set; }
         private int? InsertAfterIndex { get; set; }
-        
+
         /// <summary>
         /// Template
         /// </summary>
@@ -71,6 +71,7 @@ namespace FastExcel
 
         private const string DEFAULT_HEADERS = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><sheetData>";
         private const string DEFAULT_FOOTERS = "</sheetData></worksheet>";
+        private const string SINGLE_SHEET = "worksheets/sheet.xml";
 
         /// <summary>
         /// Constructor
@@ -355,7 +356,8 @@ namespace FastExcel
             IEnumerable<Row> rows = null;
 
             var headings = new List<string>();
-            using (Stream stream = FastExcel.Archive.GetEntry(FileName).Open())
+            string filename = DecideFilename();
+            using (Stream stream = FastExcel.Archive.GetEntry(filename).Open())
             {
                 var document = XDocument.Load(stream);
                 int skipRows = 0;
@@ -377,6 +379,18 @@ namespace FastExcel
 
             Headings = headings;
             Rows = rows;
+        }
+
+        /// <summary>
+        /// Check if single sheet exists, and use that name accordingly.
+        /// </summary>
+        /// <returns>Filename</returns>
+        private string DecideFilename()
+        {
+            var filename = FastExcel.Archive.Entries.FirstOrDefault(x => x.FullName.Contains(SINGLE_SHEET))?.FullName;
+            if (filename == null)
+                filename = FileName;
+            return filename;
         }
 
         /// <summary>

--- a/FastExcel/Worksheet.cs
+++ b/FastExcel/Worksheet.cs
@@ -219,6 +219,49 @@ namespace FastExcel
 
             Rows = newRows;
         }
+        
+        /// <summary>
+        /// Convert Rows back to Object
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="rows"></param>
+        /// <returns></returns>
+        public List<T> MapToObject<T>(IEnumerable<Row> rows, int existingHeadingRows = 0)
+        {
+            int rowNumber = existingHeadingRows + 1;
+
+            var collectionType = typeof(List<>).MakeGenericType(typeof(T));
+            var list = Activator.CreateInstance(collectionType);
+
+            var addMethod = collectionType.GetMethod("Add");
+          
+            // Get all property for map
+            IEnumerable<PropertyInfo> properties = typeof(T).GetRuntimeProperties();
+            foreach (Row row in rows.Skip(existingHeadingRows))
+            {
+                int propertyIndex = 1;
+                var objectInstance = Activator.CreateInstance(typeof(T));
+                foreach (PropertyInfo propertyInfo in properties)
+                {
+                    var colName = Cell.GetExcelColumnName(propertyIndex);
+                    if (row.Cells.Where(x => x.ColumnName == colName && x.RowNumber == rowNumber).Any())
+                    {
+                        var value = row.Cells.Where(x => x.ColumnName == colName && x.RowNumber == rowNumber).SingleOrDefault().Value;
+                        if (propertyInfo.PropertyType == typeof(DateTime))
+                        {
+                            double dateValue;
+                            if (double.TryParse(value.ToString(), out dateValue))
+                                value = DateTime.FromOADate(dateValue);
+                        }
+                        propertyInfo.SetValue(objectInstance, Convert.ChangeType(value,propertyInfo.PropertyType));
+                    }
+                    propertyIndex++;
+                }
+                rowNumber++;
+                addMethod.Invoke(list, new object[] { objectInstance });
+            }
+            return (List<T>)list;
+        }
 
         /// <summary>
         /// Add a row using a collection of value objects

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
 - Does not use the Open XML SDK to interact with the data but going directly and editing the underlying xml files.
 - This project is not intended to be a replacement for full featured Excel packages with things like formatting, just light weight fast way of interacting with data in Excel.
 
+#### Version 3.1
+- Contribute using Visual Studio 2019
+- Built using [.NetStandard](https://docs.microsoft.com/en-us/dotnet/standard/library) 2.1 targeting:
+	- .Net Standard 2.1
+    - .Net 5.0
+    - .Net 6.0
+
 #### Version 3
 - Contribute using Visual Studio 2017
 - Built using [.NetStandard](https://docs.microsoft.com/en-us/dotnet/standard/library) 2 targeting:


### PR DESCRIPTION
~Updated to .Net Standard 2.1 for library
~ Updated to .Net 6.0 for Tests
~ Updated All Nuget Packages to Latest Versions
~ Pulled In Changes From PR #64 and PR #62 into Here
~ Fixed all Message and Warnings that appeared in IDE
++ Added some Exceptions to places missing errors temporarily (Will Change them to be custom exceptions)
~ Optimized Some Code to Take advantage of newer Language Features accessible in .Net Standard 2.1
~ UpdateWorkbook() Now Has an Optional Bool parameter Called Update Which replaces the update variable that was inside of it to allow for the optional to call into the if statement that was using it, since for some reason it was never possible before.